### PR TITLE
Threaded track processing.

### DIFF
--- a/seiri-watcher/Cargo.lock
+++ b/seiri-watcher/Cargo.lock
@@ -155,13 +155,13 @@ dependencies = [
 
 [[package]]
 name = "katatsuki"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "libkatatsuki-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libkatatsuki-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -192,7 +192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libkatatsuki-sys"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -336,6 +336,14 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "num_cpus"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ole32-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,14 +480,14 @@ dependencies = [
 
 [[package]]
 name = "seiri"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "katatsuki 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "katatsuki 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_sqlite 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -499,7 +507,8 @@ dependencies = [
  "notify 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "seiri 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seiri 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -590,6 +599,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -739,12 +756,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum inotify 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887fcc180136e77a85e6a6128579a719027b1bab9b1c38ea4444244fe262c20c"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
-"checksum katatsuki 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "65b90edca6b18e1d3dfda5cdad86482e858532b37a1be9ab7a9178a17948deb5"
+"checksum katatsuki 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b6810f9ce4f00b8d2aededa13b764a5a61759eff4cd882adbcd1e2fa97c22456"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
-"checksum libkatatsuki-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ac62b093e8347a865e10678ef53b41dd792fda26b5fb9ed4ef0392dadb9f161a"
+"checksum libkatatsuki-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dc29c3c34030514d1b969ba8121b7c17839df3304b99233a9398342db126cd"
 "checksum libsqlite3-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e9eb7b8e152b6a01be6a4a2917248381875758250dc3df5d46caf9250341dda"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
@@ -760,6 +777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
+"checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8b30dc85588cd02b9b76f5e386535db546d21dc68506cff2abebee0b6445e8e4"
@@ -777,7 +795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9409d78a5a9646685688266e1833df8f08b71ffcae1b5db6c1bfb5970d8a80f"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a2ff3fc5223829be817806c6441279c676e454cc7da608faf03b0ccc09d3889"
-"checksum seiri 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4c5910ec8badbad14b54c6dbf4a3a6ccf04d71ee2ca8214bbb8b86ea1da7a35"
+"checksum seiri 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe0ce417524cf7da4c7973d498b79fb82ff1eb6052d49eccf3b250cd30a1919"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "4c36359ac1a823e00db02a243376ced650f088dc1f6259bbf828e4668e3c7399"
@@ -789,6 +807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91b52877572087400e83d24b9178488541e3d535259e04ff17a63df1e5ceff59"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
 "checksum tree_magic 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a349b03c8fb481a9e22f4650112a89be9586388a31ae30e504dab15da2f9582b"

--- a/seiri-watcher/Cargo.toml
+++ b/seiri-watcher/Cargo.toml
@@ -9,6 +9,7 @@ notify = "4.0.3"
 rand = "0.4.2"
 walkdir = "2"
 seiri = "0.6.4"
+threadpool = "1.7.1"
 
 [dependencies.rusqlite]
 version = "0.13.0"

--- a/seiri-watcher/src/watcher.rs
+++ b/seiri-watcher/src/watcher.rs
@@ -1,17 +1,17 @@
-extern crate notify;
-
-use seiri::config::Config;
-
+use notify;
 use notify::DebouncedEvent;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use seiri::config::Config;
+use seiri::database::{Connection, ConnectionPool};
 use seiri::paths::is_in_hidden_path;
-use seiri::database::{ConnectionPool, Connection};
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver};
+use std::sync::{Arc};
+use std::thread;
 use std::time::Duration;
+use threadpool::ThreadPool;
 use walkdir::{DirEntry, WalkDir};
-
 fn check_idle(path: &PathBuf) -> bool {
     return match OpenOptions::new()
         .read(true)
@@ -41,12 +41,7 @@ fn is_hidden_file(entry: &PathBuf) -> bool {
         .unwrap_or(false)
 }
 
-pub fn list<F>(
-    watch_dir: &str,
-    config: &Config,
-    pool: &ConnectionPool,
-    process: F,
-) -> ()
+pub fn list<F>(watch_dir: &str, config: &Config, pool: &ConnectionPool, process: F) -> ()
 where
     F: Fn(&Path, &Config, &Connection) -> (),
 {
@@ -68,16 +63,19 @@ pub enum WatchStatus {
 
 pub fn watch<F>(
     watch_dir: &str,
-    config: &Config,
-    pool: &ConnectionPool,
+    config: Config,
+    pool: ConnectionPool,
     process: F,
     quit_rx: Receiver<WatchStatus>,
 ) -> notify::Result<()>
 where
-    F: Fn(&Path, &Config, &Connection) -> (),
+    F: Fn(&Path, &Config, &Connection) -> () + Send + Sync + Copy + 'static,
 {
     let (tx, rx) = channel();
-
+    let exec_pool = ThreadPool::new(8);
+    let db_pool = Arc::new(pool);
+    let config = Arc::new(config);
+   // let process = Arc::new(process);
     // Automatically select the best implementation for your platform.
     // You can also access each implementation directly e.g. INotifyWatcher.
     let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(1))?;
@@ -89,6 +87,12 @@ where
     // This is a simple loop, but you may want to use more complex logic here,
     // for example to handle I/O.
     let watch_dir = Path::new(watch_dir);
+
+    // process(&*path.to_owned()
+    // , &config.clone(), &db_pool.clone().get().unwrap());
+    // let res: Result<(), ()> = Ok(());
+    //                             res
+
     loop {
         select! {
             event = rx.recv() => match event {
@@ -98,12 +102,34 @@ where
                     // Otherwise, the write event will be delayed until the latest possible.
                     if let DebouncedEvent::Write(ref path) = event {
                         if check_idle(path) && !is_in_hidden_path(path, watch_dir) && !is_hidden_file(path) {
-                            process(path, config, &pool.get().unwrap());
+                            let db_pool = Arc::clone(&db_pool);
+                            let config = Arc::clone(&config);
+                            let path = path.clone();
+                            exec_pool.execute(move || {
+                                println!("Started processing thread! Waiting 500ms for settling.");
+                                thread::sleep(Duration::from_millis(500));
+                                let pool_ref = &db_pool;
+                                let config = config.as_ref();
+                                let db_conn = pool_ref.get().unwrap();
+                                let path = path.as_path();
+                                process(path, config, &db_conn);
+                            });
                         }
                     }
                     if let DebouncedEvent::Create(ref path) = event {
                         if check_idle(path) && !is_in_hidden_path(path, watch_dir) && !is_hidden_file(path) {
-                            process(path, config, &pool.get().unwrap());
+                            let db_pool = db_pool.clone();
+                            let config = config.clone();
+                            let path = path.clone();
+                            exec_pool.execute(move || {
+                                println!("Started processing thread! Waiting 500ms for settling.");
+                                thread::sleep(Duration::from_millis(500));
+                                let pool_ref = &db_pool;
+                                let config = config.as_ref();
+                                let db_conn = pool_ref.get().unwrap();
+                                let path = path.as_path();
+                                process(path, config, &db_conn);
+                            });
                         }
                     }
                 }


### PR DESCRIPTION
Spawn a new thread to process tracks concurrently, allowing a 500ms wait time to allow tracks to settle to ensure that tracks aren't copied halfway.